### PR TITLE
Fix: use getUTCDate to align across timezones and not fail test

### DIFF
--- a/src/a09-dates/src/index.js
+++ b/src/a09-dates/src/index.js
@@ -2,5 +2,5 @@ export function getCurrentFormattedDate() {
   const now = new Date()
   return `${now.getFullYear()}-${(now.getMonth() + 1)
     .toString()
-    .padStart(2, '0')}-${now.getDate().toString().padStart(2, '0')}`
+    .padStart(2, '0')}-${now.getUTCDate().toString().padStart(2, '0')}`
 }


### PR DESCRIPTION
PR for Issue #43

Hi! I recently took part in the node test runner workshop with Marco and noticed there was a bug in the `a09-dates` test.
I'm located in the Americas Central Timezone, so when running the test the date returned was a day before:

Actual: 2024-02-18
Expected: 2024-02-19

Trying to debug the problem, I noticed that the `getCurrentFormattedDate()` function is calling the `getDate()` function to obtain the day of the month which, according to its description: _Gets the day-of-the-month, **using local time.**_. Reading further, I found there is a method called `getUTCDate` that according to its description: _Gets the day-of-the-month, **using Universal Coordinated Time (UTC)**._ (Which I believe was the original intention for the test to work across the world).

I open this Pull Request with the fix so that it can work for anyone else in the future who runs the test on any timezone.
Let me know if there's a standard way of making pull requests or if there's anything else I need to do before submitting this PR.
Hope I was of help!

Jose  Ortiz

